### PR TITLE
add empty line

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -109,6 +109,7 @@ SECTION_CLEAN_UP = 'clean_up'
 CLEAN_UP_SETTING_TRASH_BIN_ROOT_DIR = 'trash_bin_dir'
 CLEAN_UP_SETTING_MOVED_JOB_DIRS_COMMENT = 'moved_job_dirs_comment'
 
+
 def read_config(path='app.cfg'):
     """
     Read the config file


### PR DESCRIPTION
Some CI tests fail with a missing empty line.